### PR TITLE
fix scope encoding in login url

### DIFF
--- a/components/LoginButton.tsx
+++ b/components/LoginButton.tsx
@@ -39,11 +39,12 @@ const LoginButton = ({ Icon, title }: { Icon?: React.ComponentType<IconProps>; t
   url.searchParams.append('redirect_uri', NEXT_PUBLIC_AUTH_REDIRECT_URI);
   url.searchParams.append('response_type', 'code');
   url.searchParams.append('resource', window.origin);
-  url.searchParams.append('scope', NEXT_PUBLIC_AUTH_SCOPES);
+  url.searchParams.append('scope', encodeURI(NEXT_PUBLIC_AUTH_SCOPES));
 
   return (
     <a
-      href={url.href}
+      // to respect '+' signs, as they break when using the `searchParams` API
+      href={url.href.replaceAll('%2B', '+')}
       css={css`
         text-decoration: none;
       `}


### PR DESCRIPTION
encodes the scopes string (so that the `URLSearchParams` doesn't turn the '+' into encoded spaces '%20'), and then replaces the encoded plus signs at the href url directly.

when using spaces instead of plus signs, the browser displays signs (as per URL spec https://url.spec.whatwg.org/#example-constructing-urlsearchparams), but the handling of those is not consistent across environments, based on my tests.
i.e. sometimes they come out as '+' (localhost), sometimes as empty spaces, and sometimes as %20 (encoding for empty space).