### PR TITLE
fix /exploration api url

### DIFF
--- a/components/pages/explorer/RepoTable.tsx
+++ b/components/pages/explorer/RepoTable.tsx
@@ -279,7 +279,7 @@ const RepoTable = (props: PageContentProps) => {
         showFilterInput={false}
         columnDropdownText={'Columns'}
         exporter={customExporters}
-        downloadUrl={urlJoin(NEXT_PUBLIC_ARRANGER_API_URL, 'api', 'download')}
+        downloadUrl={urlJoin(NEXT_PUBLIC_ARRANGER_API_URL, 'download')}
       />
     </div>
   );

--- a/components/pages/explorer/index.tsx
+++ b/components/pages/explorer/index.tsx
@@ -78,7 +78,7 @@ const RepositoryPage = () => {
   const [loadingArrangerConfig, setLoadingArrangerConfig] = useState<boolean>(true);
 
   useEffect(() => {
-    fetch(urlJoin(NEXT_PUBLIC_ARRANGER_API_URL, 'api', 'graphql'), {
+    fetch(urlJoin(NEXT_PUBLIC_ARRANGER_API_URL, 'graphql'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/components/utils/arrangerFetcher.ts
+++ b/components/utils/arrangerFetcher.ts
@@ -30,7 +30,7 @@ const createArrangerFetcher = ({
   const { NEXT_PUBLIC_ARRANGER_API_URL } = getConfig();
 
   return ({ method = 'post', body = {}, headers = {} }) => {
-    const uri = urlJoin(NEXT_PUBLIC_ARRANGER_API_URL, 'api', 'graphql');
+    const uri = urlJoin(NEXT_PUBLIC_ARRANGER_API_URL, 'graphql');
 
     return ajax
       .post(uri, body, {


### PR DESCRIPTION
previously I was providing the api url root in env vars, and adding the /api route per request, as needed.
this removes the resulting duplicated route level, as the api url value includes it in DEV