### PR TITLE
fix queries urls being overwritten while editing their labels

### DIFF
--- a/components/pages/explorer/QueryActions/index.tsx
+++ b/components/pages/explorer/QueryActions/index.tsx
@@ -102,14 +102,18 @@ const QueryActions = ({ sqon }: { sqon: RepoFiltersType }) => {
     };
 
   const editQuery =
-    (queryId: string, previousLabel: string): MouseEventHandler<Element> =>
+    (
+      queryId: string,
+      previousLabel: string,
+      previousQueryUrl: string,
+    ): MouseEventHandler<Element> =>
     (event) => {
       setShowModal({
         actionType: 'editQuery',
         callback: (label) => {
           const data = {
             label,
-            url: currentQueryUrl,
+            url: previousQueryUrl,
           };
 
           callQueryStorage({
@@ -234,7 +238,7 @@ const QueryActions = ({ sqon }: { sqon: RepoFiltersType }) => {
                     size="11px"
                   />
                 )}
-                onClick={editQuery(queryId, label)}
+                onClick={editQuery(queryId, label, queryData.url)}
               />
               <IconButton
                 Icon={() => (

--- a/components/pages/explorer/QueryActions/utils/index.tsx
+++ b/components/pages/explorer/QueryActions/utils/index.tsx
@@ -41,8 +41,8 @@ const useQueryStorage = ({ token = '', userId = '' }: { token?: string; userId?:
       })
         .then((response: AxiosResponse) => {
           if ([200, 204].includes(response.status)) {
-            setCurrentEtag(response.data.etag);
-            setStoredQueries(response.data.queries);
+            response.data.etag && setCurrentEtag(response.data.etag);
+            response.data.queries && setStoredQueries(response.data.queries);
 
             return response.data;
           }


### PR DESCRIPTION
Avoids overwriting the query's URL; and as a bonus, handles an app crash when the API rejects the query label not being changed.